### PR TITLE
Add test cases

### DIFF
--- a/consumers/consumers.go
+++ b/consumers/consumers.go
@@ -29,6 +29,6 @@ func (d DataPrinterConsumer) Consume(i interface{}) {
 // Consume consumes an error by printing it.
 func (e ErrorPrinterConsumer) Consume(err error) {
 	if err != nil {
-		fmt.Printf("worker error: %s", err.Error())
+		fmt.Printf("worker error: %s\n", err.Error())
 	}
 }

--- a/job.go
+++ b/job.go
@@ -36,7 +36,7 @@ func NewJob(name string, workers *[]Worker) *Job {
 		jobWaitGroup:    new(sync.WaitGroup),
 		inProgress:      utils.NewAtomicBool(false),
 	}
-	job.jobWaitGroup.Add(1)
+	job.jobWaitGroup.Add(2)
 	return job
 }
 
@@ -53,6 +53,7 @@ func (j *Job) consumeErrors() {
 	for err := range j.errorChannel {
 		j.ErrorConsumer.Consume(err)
 	}
+	defer j.jobWaitGroup.Done()
 }
 
 // waitForWorkers blocks until all Workers have finished executing.

--- a/job_test.go
+++ b/job_test.go
@@ -4,6 +4,7 @@
 package jobs_test
 
 import (
+	"github.com/jake-hansen/jobs/consumers"
 	"testing"
 
 	"github.com/jake-hansen/jobs"
@@ -25,6 +26,8 @@ func TestNewJob(t *testing.T) {
 
 		assert.Equal(t, testJobName, job.Name)
 		assert.Equal(t, &workers, job.Workers)
+		assert.Equal(t, consumers.DataPrinterConsumer{}, job.DataConsumer)
+		assert.Equal(t, consumers.ErrorPrinterConsumer{}, job.ErrorConsumer)
 	})
 }
 

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"math/rand"
 	"strconv"
-	"sync"
 	"testing"
 	"time"
 
@@ -65,8 +64,8 @@ func TestScheduler_Schedule(t *testing.T) {
 		errWorkers := make([]jobs.Worker, 0)
 		errWorkers = append(errWorkers, *errWorker)
 		job := jobs.NewJob("test job", &errWorkers)
-		consumer := &errConsumer{}
-		job.ErrorConsumer = consumer
+		consumer := errConsumer{}
+		job.ErrorConsumer = &consumer
 		err := jobs.DefaultScheduler().SubmitJob(job)
 
 		job.Wait()
@@ -87,7 +86,6 @@ func (i integerTask) Run() (interface{}, error) {
 }
 
 type additionConsumer struct {
-	mu  sync.Mutex
 	Sum int
 }
 
@@ -99,12 +97,13 @@ func (a *additionConsumer) Consume(data interface{}) {
 }
 
 type errTask struct {}
-type errConsumer struct {
-	err error
-}
 
 func (e errTask) Run() (interface{}, error) {
 	return nil, errors.New("test error")
+}
+
+type errConsumer struct {
+	err error
 }
 
 func (e *errConsumer) Consume(err error) {

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -4,6 +4,7 @@
 package jobs_test
 
 import (
+	"errors"
 	"fmt"
 	"math/rand"
 	"strconv"
@@ -41,13 +42,14 @@ func TestScheduler_Schedule(t *testing.T) {
 
 		testJob := jobs.NewJob("test job", testWorkers)
 		testScheduler := jobs.DefaultScheduler()
+		testScheduler.Debug = true
 		consumer := additionConsumer{Sum: 0}
 		testJob.DataConsumer = &consumer
 		err := testScheduler.SubmitJob(testJob)
 		testJob.Wait()
 
 		assert.NoError(t, err)
-		assert.Equal(t, len(*testWorkers)*5, consumer.safeSumRead())
+		assert.Equal(t, len(*testWorkers)*5, consumer.Sum)
 	})
 
 	t.Run("failure-nil-job", func(t *testing.T) {
@@ -55,6 +57,22 @@ func TestScheduler_Schedule(t *testing.T) {
 		err := testScheduler.SubmitJob(nil)
 
 		assert.Error(t, err)
+	})
+
+	t.Run("job-with-worker-errors", func(t *testing.T) {
+		var task jobs.Task = &errTask{}
+		errWorker := jobs.NewWorker(&task, "test worker", nil)
+		errWorkers := make([]jobs.Worker, 0)
+		errWorkers = append(errWorkers, *errWorker)
+		job := jobs.NewJob("test job", &errWorkers)
+		consumer := &errConsumer{}
+		job.ErrorConsumer = consumer
+		err := jobs.DefaultScheduler().SubmitJob(job)
+
+		job.Wait()
+
+		assert.NoError(t, err)
+		assert.Error(t, consumer.err)
 	})
 }
 
@@ -73,25 +91,22 @@ type additionConsumer struct {
 	Sum int
 }
 
-// safeSumRead is a thread safe implementation to read the Sum
-// variable.
-func (a *additionConsumer) safeSumRead() int {
-	a.mu.Lock()
-	defer a.mu.Unlock()
-	return a.Sum
-}
-
-// safeSumWrite() is a thread safe implementation to write the Sum
-// variable.
-func (a *additionConsumer) safeSumWrite(value int) {
-	a.mu.Lock()
-	defer a.mu.Unlock()
-	a.Sum += value
-}
-
 func (a *additionConsumer) Consume(data interface{}) {
 	integer, ok := data.(int)
 	if ok {
-		a.safeSumWrite(integer)
+		a.Sum += integer
 	}
+}
+
+type errTask struct {}
+type errConsumer struct {
+	err error
+}
+
+func (e errTask) Run() (interface{}, error) {
+	return nil, errors.New("test error")
+}
+
+func (e *errConsumer) Consume(err error) {
+	e.err = err
 }


### PR DESCRIPTION
This PR adds more test cases to reach 100% code coverage. This PR also fixes a race condition that occurs within handling of the error channel on a Job. This is similar to the fix that was applied for the data channel race condition in #1.

* Removes unnecessary goroutine synchronization from test cases.